### PR TITLE
fix: self-destroy the old Gatsby service worker

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -16,6 +16,7 @@ export default function (eleventyConfig) {
   });
 
   eleventyConfig.addPassthroughCopy({ "src/media": "/" });
+  eleventyConfig.addPassthroughCopy({ "src/sw.js": "sw.js" });
   eleventyConfig.addPassthroughCopy("src/css");
   eleventyConfig.addPassthroughCopy("src/fonts");
 

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,20 @@
+// Self-destroying service worker. The previous Gatsby site registered a
+// service worker at /sw.js; browsers that still have it keep serving the old
+// app shell, which breaks every page on the rebuilt site. This replacement
+// takes over, wipes the old caches, unregisters itself, and reloads open
+// tabs. Keep serving it indefinitely so long-absent visitors get cleaned up.
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((key) => caches.delete(key)));
+      await self.registration.unregister();
+      const clients = await self.clients.matchAll({ type: "window" });
+      clients.forEach((client) => client.navigate(client.url));
+    })(),
+  );
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,12 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": "_site"
+  "outputDirectory": "_site",
+  "headers": [
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, must-revalidate" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
The previous Gatsby site registered a service worker at /sw.js that still hijacks navigation in returning visitors' browsers, serving the stale app shell and blank-screening every page but home. Serve a replacement worker that wipes caches, unregisters itself, and reloads open tabs, with no-cache headers so update checks always see it.